### PR TITLE
Stipped event specific names and made them configurable

### DIFF
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -267,7 +267,7 @@ h3.slider-control {
 
 .session-list-item,
 .open-block,
-.pathway-list-item  {
+.tag-list-item  {
   display: block;
   clear: both;
   position: relative;
@@ -281,14 +281,14 @@ h3.slider-control {
 }
 
 .session-list-item,
-.pathway-list-item {
+.tag-list-item {
   color: #55565A;
   text-decoration: none;
 }
 
 .session-list-item h4,
-.space-list-item h4,
-.pathway-list-item  h4 {
+.category-list-item h4,
+.tag-list-item  h4 {
   margin: 0 6rem 2rem 0;
   line-height: 1.2;
   font-size: 3rem;
@@ -353,16 +353,16 @@ a.page-control {
 
 .session-facilitators,
 .session-time,
-.session-space-and-location,
-.session-pathways {
+.session-category-and-location,
+.session-tags {
   position: relative;
   padding-left: 25px;
 }
 
 .session-facilitators:before,
 .session-time:before,
-.session-space-and-location:before,
-.session-pathways:before {
+.session-category-and-location:before,
+.session-tags:before {
   display: block;
   content: "";
   background-size: 20px auto;
@@ -382,12 +382,12 @@ a.page-control {
   top: 4px;
 }
 
-.session-space-and-location:before {
+.session-category-and-location:before {
   background-image: url(../img/icon-space.svg);
   top: 6px;
 }
 
-.session-pathways:before {
+.session-tags:before {
   background-image: url(../img/icon-pathway.svg);
   top: 4px;
 }
@@ -439,7 +439,7 @@ a.page-control {
 .session-time {
 
 }
-.session-space-and-location {
+.session-category-and-location {
 
 }
 
@@ -450,32 +450,32 @@ a.page-control {
   margin-bottom: 2rem;
 }
 
-.space-list-item {
+.category-list-item {
   padding: 4rem;
 }
 
-.space-list-item h4,
-.pathway-list-item h4 {
+.category-list-item h4,
+.tag-list-item h4 {
   margin-left: 0;
 }
 
-.space-list-item .space-icon-container {
+.category-list-item .category-icon-container {
   float: left;
   padding-left: 1rem;
   padding-right: 2rem;
 }
 
-.space-list-item .space-icon-container img {
+.category-list-item .category-icon-container img {
   width: 12rem;
   height: auto;
 }
 
-.space-list-item:nth-child(2n+1) {
+.category-list-item:nth-child(2n+1) {
   background: #f5f5f5;
 }
 
-.space-list-item p:last-child,
-.pathway-list-item p:last-child {
+.category-list-item p:last-child,
+.tag-list-item p:last-child {
   margin-bottom: 0;
 }
 
@@ -565,11 +565,11 @@ a.page-control {
     top: 2px;
   }
 
-  .session-space-and-location:before {
+  .session-category-and-location:before {
     top: 3px;
   }
 
-  .session-pathways:before {
+  .session-tags:before {
     top: 2px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -28,9 +28,6 @@
             <a href="https://2015.mozillafestival.org/"><img src="img/logo-mozilla-festival.svg" alt="MozFest"></a>
           </div>
           <div id="page-links">
-            <a href="https://2015.mozillafestival.org/tickets">Tickets</a>
-            <a href="#_spaces" id="spaces-page-link">Spaces</a>
-            <a href="#_pathways" id="pathways-page-link">Pathways</a>
           </div>
         </div>
       </nav>
@@ -115,7 +112,7 @@
     </script>
 
     <script type="text/template" id="session-card-template">
-    <a href="#_session-<%= sessionID %>" id="session-<%= sessionID %>" class="session-list-item<% if (session.space == 'Everyone') { %> session-everyone<% } %>" data-session="<%= sessionID.replace('-ghost','') %>">
+    <a href="#_session-<%= sessionID %>" id="session-<%= sessionID %>" class="session-list-item<% if (session.category == 'Everyone') { %> session-everyone<% } %>" data-session="<%= sessionID.replace('-ghost','') %>">
       <h4><%= smartypants(session.title) %></h4>
       <div>
         <% if (showFacilitators && session.facilitators) { %>
@@ -128,14 +125,14 @@
           <% if (session.day) { %><%= session.day %>, <% } %><%= session.start %>
         </div>
         <% } %>
-        <% if (session.space || session.location) { %>
-        <div class="session-space-and-location">
-          <% if (session.space) { %><%= session.space %><% } %><% if (session.space&&session.location) { %>, <% } %><% if (session.location) { %><%= smartypants(session.location) %><% } %>
+        <% if (session.category || session.location) { %>
+        <div class="session-category-and-location">
+          <% if (session.category) { %><%= session.category %><% } %><% if (session.category&&session.location) { %>, <% } %><% if (session.location) { %><%= smartypants(session.location) %><% } %>
         </div>
         <% } %>
-        <% if (session.pathways) { %>
-        <div class="session-pathways">
-          <%= session.pathways %>
+        <% if (session.tags) { %>
+        <div class="session-tags">
+          <%= session.tags %>
         </div>
         <% } %>
       </div>
@@ -150,14 +147,14 @@
         <% if (session.day) { %><%= session.day %>, <% } %><%= session.start %>
       </div>
       <% } %>
-      <% if (session.space || session.location) { %>
-      <div class="session-space-and-location">
-        <% if (session.space) { %><%= session.space %><% } %><% if (session.space&&session.location) { %>, <% } %><% if (session.location) { %><%= smartypants(session.location) %><% } %>
+      <% if (session.category || session.location) { %>
+      <div class="session-category-and-location">
+        <% if (session.category) { %><%= session.category %><% } %><% if (session.category&&session.location) { %>, <% } %><% if (session.location) { %><%= smartypants(session.location) %><% } %>
       </div>
       <% } %>
-       <% if (session.pathways) { %>
-      <div class="session-pathways">
-        <%= session.pathways %>
+       <% if (session.tags) { %>
+      <div class="session-tags">
+        <%= session.tags %>
       </div>
       <% } %>
       <% if (showFacilitators && session.facilitators.length > 0) { %>
@@ -186,16 +183,16 @@
             <% if (session.day) { %><%= session.day %>, <% } %><%= session.start %>
           </div>
           <% } %>
-          <% if (session.space || session.location) { %>
-          <div class="session-space-and-location">
-            <% if (session.space) { %>
-              <a href="#_space-<%= slugify(session.space) %>"><%= session.space %></a><% } %><% if (session.space&&session.location) { %>, <% } %><% if (session.location) { %><%= smartypants(session.location) %><% } %>
+          <% if (session.category || session.location) { %>
+          <div class="session-category-and-location">
+            <% if (session.category) { %>
+              <a href="#_<%= customCategoryLabel %>-<%= slugify(session.category) %>"><%= session.category %></a><% } %><% if (session.category&&session.location) { %>, <% } %><% if (session.location) { %><%= smartypants(session.location) %><% } %>
           </div>
           <% } %>
-          <% if (session.pathways && session.pathwayArray.length) { %>
-          <div class="session-pathways">
-            <% session.pathwayArray.forEach(function(name, index) { %><% if (index > 0) { %>, <% } %>
-              <a href="#_pathway-<%= slugify(name) %>"><%= name %></a><% }) %>
+          <% if (session.tags && session.tagArray.length) { %>
+          <div class="session-tags">
+            <% session.tagArray.forEach(function(name, index) { %><% if (index > 0) { %>, <% } %>
+              <a href="#_<%= customTagLabel %>-<%= slugify(name) %>"><%= name %></a><% }) %>
           </div>
           <% } %>
           <% if (session.facilitators) { %>
@@ -213,24 +210,24 @@
     </div>
     </script>
 
-    <script type="text/template" id="spaces-list-template">
-      <div class="space-list-item" data-space="<%= space.slugify(space.name) %>">
-        <div class="space-icon-container">
-          <img src=<%= space.iconSrc %>>
+    <script type="text/template" id="categories-list-template">
+      <div class="category-list-item" data-category="<%= category.slugify(category.name) %>">
+        <div class="category-icon-container">
+          <img src=<%= category.iconSrc %>>
         </div>
-        <h4><%= space.name %></h4>
+        <h4><%= category.name %></h4>
         <div>
-          <a class="see-all-events-in-this-space" href="#_space-<%= space.slugify(space.name) %>">See all events in this Space</a>
-          <% space.description.forEach(function(p) { %>
+          <a class="see-all-events-in-this-category" href="#_<%= customCategoryLabel %>-<%= category.slugify(category.name) %>">See all events in this <%= customCategoryLabel %></a>
+          <% category.description.forEach(function(p) { %>
             <%= marked(p) %>
           <% }) %>
         </div>
       </div>
     </script>
 
-    <script type="text/template" id="pathways-list-template">
+    <script type="text/template" id="tags-list-template">
       <% if (name) { %>
-      <a href="#_pathway-<%= slugify(name) %>" class="pathway-list-item" data-pathway="<%= slugify(name) %>">
+      <a href="#_<%= customTagLabel %>-<%= slugify(name) %>" class="tag-list-item" data-tag="<%= slugify(name) %>">
         <h4><%= name %></h4>
         <p><%= numSessions %> session<% if (numSessions>1) { %>s<% } %></p>
         <% if (description.length) { %><% description.forEach(function(p) { %>
@@ -244,5 +241,37 @@
     <script src="js/underscore-min.js"></script>
     <script src="js/marked.min.js"></script>
     <script src="js/schedule.js"></script>
+    <script>
+      var customConfig = {
+        displayNameForCategory: {
+          singular:'theSpace',
+          plural: 'theSpaces'
+        },
+        displayNameForTag: {
+          singular:'thePathway',
+          plural: 'thePathways'
+        },
+        pathToSessionsJson: 'sessions-converted.json',
+        pathToCategoriesJson: 'spaces.json',
+        pathToTagsJson: 'pathways.json',
+        localStoragePrefix: 'test-event',
+        // MozFest calls this "session" while Hive Buzz calls this "moonshot"
+        categoryType: 'session',
+        tabList: [
+          { name: 'Friday', displayName: 'Fri', tabDate: new Date(2015,10,6) },
+          { name: 'Saturday', displayName: 'Sat', tabDate: new Date(2015,10,7) },
+          { name: 'Sunday', displayName: 'Sun', tabDate: new Date(2015,10,8) },
+          { name: 'All', displayName: 'All' }
+        ],
+        additionalNavItems: [
+          {
+            label: "Ticket",
+            link: "https://2015.mozillafestival.org/tickets",
+          }
+        ]
+      }
+      // instantiate the app
+      new Schedule(customConfig);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #156 

- MozFest term "Space" is generalized as "Category" (a session can only belong to ONE Category)
- MozFest term "Pathway" is generalized as "Tag" (a session can only belong to MULTIPLE Tag)

The display name for these 2 meta can be configured when you initiate the `Schedule` instance.
e.g.
```js
var customConfig = {
  displayNameForCategory: {
    singular:'theSpace',
    plural: 'theSpaces'
  },
  displayNameForTag: {
    singular:'thePathway',
    plural: 'thePathways'
  },
  ...
}
// instantiate the app
new Schedule(customConfig);
```

Note: I should probably add a "pluralizer" helper function... I'll leave it as a todo for now.