### PR TITLE
Some UX / UI tweaks

### DIFF
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -130,6 +130,11 @@ h2 {
   margin-top: 0;
 }
 
+input {
+  font-size: 1.8rem;
+  padding: 5px;
+}
+
 header a {
   white-space: nowrap;
 }
@@ -235,7 +240,7 @@ header a {
   font-size: 3.1rem;
   padding: .5rem .1rem .5rem .8rem;
   background-color: #fff;
-  color: #b7baba;
+  color: #D93F5F;
 }
 h3.slider-control {
   cursor: pointer;
@@ -271,7 +276,6 @@ h3.slider-control {
   display: block;
   clear: both;
   position: relative;
-  cursor: pointer;
   padding: 4rem;
   margin: 0 0 3rem 0;
   -webkit-border-radius: 2px;
@@ -313,7 +317,7 @@ a.page-control {
 #filter-form {
   padding: 0;
   margin-bottom: 3rem;
-  width: 50%;
+  width: 100%;
   float: left;
 }
 
@@ -322,6 +326,11 @@ a.page-control {
   width: 100%;
   margin-top: .5rem;
 }
+
+#show-descriptions {
+  margin-bottom: 20px;
+}
+
 #no-results {
 
 }
@@ -333,6 +342,7 @@ a.page-control {
 .favorite {
   color: #B94D60;
   font-size: 3.5rem;
+  width: 4rem;
   position: absolute;
   cursor: pointer;
   top: 3.5rem;
@@ -340,7 +350,6 @@ a.page-control {
   line-height: 1;
   margin-top: .7rem;
   text-align: center;
-
 }
 
 .favorite-active .fa-heart-o:before {
@@ -357,6 +366,7 @@ a.page-control {
 .session-tags {
   position: relative;
   padding-left: 25px;
+  text-transform: capitalize;
 }
 
 .session-facilitators:before,
@@ -540,9 +550,6 @@ a.page-control {
   .container {
     padding: 0 4rem;
   }
-  #filter-form {
-    width: 100%;
-  }
   .page-control {
     display: inline-block;
     padding: 0;
@@ -585,6 +592,7 @@ a.page-control {
     float: none;
   }
   #page-links {
+    display: block;
     float: none;
     margin-top: 0;
     margin-bottom: 2rem;

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -628,7 +628,7 @@ function Schedule(CUSTOM_CONFIG) {
       // show "no results" if search input value matches zero items
       if ($('.session-list-item:visible').length == 0) {
         $('#no-results').remove();
-        $('#filter-form label').after('<p id="no-results">No matching results found.</p>');
+        $('#filter-form input').after('<p id="no-results">No matching results found.</p>');
       } else {
         $('#no-results').remove();
       }
@@ -641,7 +641,7 @@ function Schedule(CUSTOM_CONFIG) {
   // showFavorites() handles display when someone chooses the "Favorites" tab
   schedule.showFavorites = function() {
     // provide some user instructions at top of page
-    schedule.$container.empty().append('<p class="overline">Favorite sessions to store a list on this device</p>').append(schedule.sessionListTemplate);
+    schedule.$container.empty().append('<p class="overline">Tap the hearts to add favorites to your list here.</p>').append(schedule.sessionListTemplate);
     // use savedSessionList IDs to render favorited sessions to page
     schedule.addSessionsToSchedule(schedule.savedSessionList);
     schedule.clearOpenBlocks();
@@ -771,10 +771,10 @@ function Schedule(CUSTOM_CONFIG) {
       schedule.getFilteredSessions("tags", tag_slug);
     });
 
-    // clicking on session "card" in a list opens session detail view
-    schedule.$container.on('click', '.session-list-item', function(e) {
+    // clicking on the header in a session "card" opens session detail view
+    schedule.$container.on('click', '.session-list-item h4 a', function(e) {
       e.preventDefault();
-      var clicked = $(this).data('session');
+      var clicked = $(this).parents('.session-list-item').data('session');
 
       // track interaction in Google Analytics
       schedule.trackEvent('Session Detail Opened', clicked);
@@ -870,7 +870,16 @@ function Schedule(CUSTOM_CONFIG) {
       var targets = $('[data-session="' + sessionID + '"]').find('.favorite');
 
       // first toggle the star class so favorited sessions are lit
-      targets.toggleClass('favorite-active');
+      targets
+        .animate({
+          fontSize: "-=5px"
+        }, 100)
+        .animate({
+          fontSize: "+=5px",
+        }, 200, function() {
+          $(this).toggleClass('favorite-active')
+        });
+
       if (clicked.hasClass('favorite-active')) {
         // if favorited, add the session ID to savedSessionIDs
         schedule.savedSessionIDs.push(sessionID);

--- a/sample-index.html
+++ b/sample-index.html
@@ -50,9 +50,10 @@
     </div>
     </script>
 
+    <!-- template used in tabs other than the search / all sessions tab view -->
     <script type="text/template" id="session-card-template">
-    <a href="#_session-<%= sessionID %>" id="session-<%= sessionID %>" class="session-list-item<% if (session.category == 'Everyone') { %> session-everyone<% } %>" data-session="<%= sessionID.replace('-ghost','') %>">
-      <h4><%= smartypants(session.title) %></h4>
+    <div id="session-<%= sessionID %>" class="session-list-item<% if (session.category == 'Everyone') { %> session-everyone<% } %>" data-session="<%= sessionID.replace('-ghost','') %>">
+      <h4><a href="#_session-<%= sessionID %>"><%= smartypants(session.title) %></a></h4>
       <div>
         <% if (showFacilitators && session.facilitators) { %>
         <div class="session-facilitators">
@@ -75,12 +76,13 @@
         </div>
         <% } %>
       </div>
-    </a>
+    </div>
     </script>
 
+    <!-- template used in the search / all sessions tab view -->
     <script type="text/template" id="session-list-item-template">
-    <a href="#_session-<%= sessionID %>" id="session-<%= sessionID %>" class="session-list-item" data-session="<%= sessionID.replace('-ghost','') %>">
-      <h4><%= smartypants(session.title) %></h4>
+    <div id="session-<%= sessionID %>" class="session-list-item" data-session="<%= sessionID.replace('-ghost','') %>">
+      <h4><a href="#_session-<%= sessionID %>"><%= smartypants(session.title) %></a></h4>
       <% if (session.start) { %>
       <div class="session-time">
         <% if (session.day) { %><%= session.day %>, <% } %><%= session.start %>
@@ -106,7 +108,7 @@
         <%= marked(session.description.replace('http://','').replace('https://','')) %>
       <% } %>
       </div>
-    </a>
+    </div>
     </script>
 
     <script type="text/template" id="session-detail-template">
@@ -149,6 +151,7 @@
     </div>
     </script>
 
+    <!-- template used in [categories] list view -->
     <script type="text/template" id="categories-list-template">
       <div class="category-list-item" data-category="<%= category.slugify(category.name) %>">
         <div class="category-icon-container">
@@ -164,15 +167,16 @@
       </div>
     </script>
 
+    <!-- template used in [tags] list view -->
     <script type="text/template" id="tags-list-template">
       <% if (name) { %>
-      <a href="#_<%= customTagLabel %>-<%= slugify(name) %>" class="tag-list-item" data-tag="<%= slugify(name) %>">
-        <h4><%= name %></h4>
+      <div class="tag-list-item" data-tag="<%= slugify(name) %>">
+        <h4><a href="#_<%= customTagLabel %>-<%= slugify(name) %>"><%= name %></a></h4>
         <p><%= numSessions %> session<% if (numSessions>1) { %>s<% } %></p>
         <% if (description.length) { %><% description.forEach(function(p) { %>
           <%= marked(p) %>
         <% }) %><% } %>
-      </a>
+      </div>
       <% } %>
     </script>
 


### PR DESCRIPTION
Relates to #181 

- search icon instead of "All"
- add padding to the search box on the "All" tab
- session title as link instead of whole card
- change colours of dropdown icons to maroon
- `text-transform: capitalize` all session fields (Title, Time, Location, Space)
- add animation when heart is clicked
- show "No matching results found." found below the search box on "All" tab
- change text on "Fav" tab from "Favorite sessions to store a list on this device" to "Tap the hearts to add favorites to your list here." 

Note that parts of the template code in `sample-index.html` are updated in this PR.